### PR TITLE
Changed so formatting do not close empty XML tag

### DIFF
--- a/rsimulator-core/src/main/java/com/github/bjuvensjo/rsimulator/core/handler/regexp/XmlHandler.java
+++ b/rsimulator-core/src/main/java/com/github/bjuvensjo/rsimulator/core/handler/regexp/XmlHandler.java
@@ -42,6 +42,9 @@ public class XmlHandler extends AbstractHandler {
             Document doc = new SAXBuilder().build(bis);
             bis.close();
             Format format = Format.getCompactFormat();
+            // Required for .* to generate match on empty element
+            // <tag>.*</tag> == <tag></tag>
+            format.setExpandEmptyElements(true);
             // To not have the ? in the declaration interpreted as regular expressions.
             format.setOmitDeclaration(true);
             XMLOutputter out = new XMLOutputter(format);


### PR DESCRIPTION
The format method in XmlHandler.java close empty tags. This means that a <tag></tag> is converted to a <tag/> when formatting. This result in that the expression <tag>.*</tag> do not match the <tag></tag>. 